### PR TITLE
Bump Autofac from 6.4.0 to 8.0.0

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "6.0.301"
+    "version": "8.0.203"
   }
 }

--- a/src/Autofac.Integration.Web/Autofac.Integration.Web.csproj
+++ b/src/Autofac.Integration.Web/Autofac.Integration.Web.csproj
@@ -40,7 +40,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.4.0" />
+    <PackageReference Include="Autofac" Version="8.0.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>All</PrivateAssets>

--- a/src/Autofac.Integration.Web/ContainerProviderContainer.cs
+++ b/src/Autofac.Integration.Web/ContainerProviderContainer.cs
@@ -163,7 +163,7 @@ public class ContainerProviderContainer : IContainer
     /// </returns>
     /// <exception cref="ComponentNotRegisteredException"/>
     /// <exception cref="Autofac.Core.DependencyResolutionException"/>
-    public object ResolveComponent(ResolveRequest request)
+    public object ResolveComponent(in ResolveRequest request)
     {
         return _containerProvider.RequestLifetime.ResolveComponent(request);
     }


### PR DESCRIPTION
We started receiving the following error after upgrading to Autofac 8:

> {"Method 'ResolveComponent' in type 'Autofac.Integration.Web.ContainerProviderContainer' from assembly 'Autofac.Integration.Web, Version=6.1.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da' does not have an implementation.":"Autofac.Integration.Web.ContainerProviderContainer"}

This appears to be due to https://github.com/autofac/Autofac/pull/1397