### PR TITLE
Update target framework to net481

### DIFF
--- a/default.proj
+++ b/default.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
-    <Version>7.0.0</Version>
+    <Version>8.0.0</Version>
     <SolutionName>Autofac.Web</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/src/Autofac.Integration.Web/Autofac.Integration.Web.csproj
+++ b/src/Autofac.Integration.Web/Autofac.Integration.Web.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- Frameworks and language features -->
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/test/Autofac.Integration.Web.Test/Autofac.Integration.Web.Test.csproj
+++ b/test/Autofac.Integration.Web.Test/Autofac.Integration.Web.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="PolySharp" Version="1.14.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -27,8 +27,8 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Integration.Web.Test/RegistrationExtensionsFixture.cs
+++ b/test/Autofac.Integration.Web.Test/RegistrationExtensionsFixture.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Reflection;
 using System.Web;
 using System.Web.SessionState;
 
@@ -25,8 +24,7 @@ public class RegistrationExtensionsFixture
 
     public static HttpContext FakeHttpContext()
     {
-        // source: https://stackoverflow.com/a/10126711/6887257
-        var httpRequest = new HttpRequest("", "http://stackoverflow/", "");
+        var httpRequest = new HttpRequest("", "http://localhost/", "");
         var stringWriter = new StringWriter();
         var httpResponse = new HttpResponse(stringWriter);
         var httpContext = new HttpContext(httpRequest, httpResponse);
@@ -41,13 +39,7 @@ public class RegistrationExtensionsFixture
             SessionStateMode.InProc,
             false);
 
-        httpContext.Items["AspSession"] = typeof(HttpSessionState).GetConstructor(
-                BindingFlags.NonPublic | BindingFlags.Instance,
-                null,
-                CallingConventions.Standard,
-                new[] { typeof(HttpSessionStateContainer) },
-                null)
-            .Invoke(new object[] { sessionContainer });
+        SessionStateUtility.AddHttpSessionStateToContext(httpContext, sessionContainer);
 
         return httpContext;
     }


### PR DESCRIPTION
## Summary
- Update target framework from `net472` to `net481` (.NET Framework 4.8.1)
- Bump version from 7.0.0 to 8.0.0 (breaking change: minimum framework requirement)
- Update test infrastructure: xunit 2.9.3, Microsoft.NET.Test.Sdk 18.0.0, xunit.runner.visualstudio 3.1.5

## Test plan
- [ ] CI build passes
- [ ] All tests pass on net481
- [ ] Note: `VerifyInstanceLifetimeIsSession` test has a pre-existing failure on develop (NullReferenceException unrelated to this change)